### PR TITLE
add CSP rules and rate limiting

### DIFF
--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -74,9 +74,9 @@ http {
 
     location = /_route-service-check {
       allow 127.0.0.1/32;
-      {{env "ALLOWED_IPS"}}
-      # auth_basic "Restricted";
-      # auth_basic_user_file .htpasswd;
+      # {{env "ALLOWED_IPS"}}
+      auth_basic "Restricted";
+      auth_basic_user_file .htpasswd;
       deny all;
 
       try_files $uri @check;
@@ -85,9 +85,9 @@ http {
     location / {
 
       allow 127.0.0.1/32;
-      {{env "ALLOWED_IPS"}}
-      # auth_basic "Restricted";
-      # auth_basic_user_file .htpasswd;
+      # {{env "ALLOWED_IPS"}}
+      auth_basic "Restricted";
+      auth_basic_user_file .htpasswd;
       deny all;
 
       # Rate limiting for this location

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -10,6 +10,10 @@ events {
 http {
   charset utf-8;
 
+  # Define a limit_req_zone for rate limiting
+  limit_req_zone $binary_remote_addr zone=login_limit:10m rate=5r/s;
+  limit_req_status 429;
+
   log_format access_json '{"logType": "nginx-access", '
                          ' "remoteHost": "$remote_addr", '
                          ' "user": "$remote_user", '
@@ -70,20 +74,24 @@ http {
 
     location = /_route-service-check {
       allow 127.0.0.1/32;
-      # {{env "ALLOWED_IPS"}}
-      auth_basic "Restricted";
-      auth_basic_user_file .htpasswd;
+      {{env "ALLOWED_IPS"}}
+      # auth_basic "Restricted";
+      # auth_basic_user_file .htpasswd;
       deny all;
 
       try_files $uri @check;
     }
 
     location / {
+
       allow 127.0.0.1/32;
-      # {{env "ALLOWED_IPS"}}
-      auth_basic "Restricted";
-      auth_basic_user_file .htpasswd;
+      {{env "ALLOWED_IPS"}}
+      # auth_basic "Restricted";
+      # auth_basic_user_file .htpasswd;
       deny all;
+
+      # Rate limiting for this location
+      limit_req zone=login_limit burst=20;
 
       resolver 169.254.0.2;
 
@@ -102,6 +110,9 @@ http {
       proxy_set_header Host $cf_forwarded_host;
       proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
 
+      add_header X-XSS-Protection "1; mode=block";
+      add_header Strict-Transport-Security: "max-age=63072000; includeSubdomains";
+      add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:;";
       # Use XX-CF-APP-INSTANCE on the original request if you wish to target an instance
       proxy_set_header X-CF-APP-INSTANCE $http_xx_cf_app_instance;
 


### PR DESCRIPTION
I've added and tested the CSP in https://help-to-heat-frontdoor-sandbox.london.cloudapps.digital/ but the CSP is blocking an inline script from running. (see the errors in the console in sandbox) I don't remember seeing this issue in other apps. Do we usually use in line scripts or can it be moved to a separate file and the use `script-src` directive in the CSP?